### PR TITLE
Fix #7

### DIFF
--- a/crates/feather/src/internals/app.rs
+++ b/crates/feather/src/internals/app.rs
@@ -92,7 +92,7 @@ impl App {
         // Run route-specific middleware
         if let Some(route) = routes
             .iter()
-            .find(|r| r.method == request.method && r.path == request.uri.to_string())
+            .find(|r| r.method == request.method && r.path == request.uri.path())
         {
             route
                 .middleware


### PR DESCRIPTION
The route path was being compared to the entire URI (including query params), but it should be compared to the URI path.

You can verify it by running the `feather-bench` package and navigating to `/user?foo`, it will display `foo`.