### PR TITLE
Fix/doc include relative path

### DIFF
--- a/crates/feather/Cargo.toml
+++ b/crates/feather/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feather"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 repository = "https://github.com/BersisSe/feather"
 description = "Feather: A minimal HTTP framework for Rust"

--- a/crates/feather/src/lib.rs
+++ b/crates/feather/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../../../README.md")]
+#![doc = include_str!("../../../README.md")]
 
 /// The [`Middleware`] trait and some common middleware primitives.
 pub mod middleware;


### PR DESCRIPTION
Current version deployed on [crates.io](https://crates.io/crates/feather) won't compile because of a wrong relative path to the `README.md` file.